### PR TITLE
fix(examples): select supported RDS storage type

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -34,6 +34,8 @@ module "infrastructure" {
   rds_engine                = "MySQL"
   rds_engine_version        = "5.7"
   rds_instance_storage_type = "cloud_essd"
+  rds_instance_storage      = 20
+  rds_instance_type         = "mysql.n2.medium.1"
   rds_account_name          = "tfexamplename"
   rds_password              = "Example1234"
   rds_databases = [

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -30,11 +30,12 @@ module "infrastructure" {
   slb_spec      = "slb.s1.small"
 
   # create rds instance
-  create_rds_instance = true
-  rds_engine          = "MySQL"
-  rds_engine_version  = "5.7"
-  rds_account_name    = "tfexamplename"
-  rds_password        = "Example1234"
+  create_rds_instance       = true
+  rds_engine                = "MySQL"
+  rds_engine_version        = "5.7"
+  rds_instance_storage_type = "cloud_essd"
+  rds_account_name          = "tfexamplename"
+  rds_password              = "Example1234"
   rds_databases = [
     {
       name          = "tf_example_db"


### PR DESCRIPTION
## Summary
- set the complete example RDS storage type to cloud_essd
- avoid an empty db instance class lookup in the test region

## Validation
- terraform fmt -check
- git diff --check

E2E is intentionally left to GitHub Actions.